### PR TITLE
Cross-platform support optimizations and general ease of use

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
-default_envs = wemos_d1_mini32
+default_envs = Wemos_D1_mini32
 name = TempTamer
 src_dir = src/arduino/TempTamer
 
@@ -17,15 +17,18 @@ src_dir = src/arduino/TempTamer
 lib_deps_external = 
 	paulstoffregen/OneWire
 	milesburton/DallasTemperature
+	bonezegei/Bonezegei_Printf@^1.0.1
 
-[env:wemos_d1_mini32]
+[env:Wemos_D1_mini32]
 platform = espressif32
 board = wemos_d1_mini32
 framework = arduino
-lib_deps = ${common.lib_deps_external}
+lib_deps = 
+	${common.lib_deps_external}
 
 [env:Arduino_NANO]
 board = nanoatmega328
 platform = atmelavr
 framework = arduino
-lib_deps = ${common.lib_deps_external}
+lib_deps = 
+	${common.lib_deps_external}

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,18 +17,34 @@ src_dir = src/arduino/TempTamer
 lib_deps_external = 
 	paulstoffregen/OneWire
 	milesburton/DallasTemperature
-	bonezegei/Bonezegei_Printf@^1.0.1
+
 
 [env:Wemos_D1_mini32]
 platform = espressif32
 board = wemos_d1_mini32
 framework = arduino
 lib_deps = 
-	${common.lib_deps_external}
+    ${common.lib_deps_external}
+    bonezegei/Bonezegei_Printf@^1.0.1
 
-[env:Arduino_NANO]
-board = nanoatmega328
+[env:Arduino_NANO_UNO]
 platform = atmelavr
+board = nanoatmega328
 framework = arduino
 lib_deps = 
-	${common.lib_deps_external}
+    ${common.lib_deps_external}
+    bonezegei/Bonezegei_Printf@^1.0.1
+
+[env:Wemos_D1_mini_8266_ESP_12]
+platform = espressif8266
+board = d1_mini
+framework = arduino
+lib_deps = 
+    ${common.lib_deps_external}
+    bonezegei/Bonezegei_Printf@^1.0.1
+
+#[env:Raspberry_PI_pico]
+#board = pico
+#platform = raspberrypi
+#framework = arduino
+#lib_deps = ${common.lib_deps_external}

--- a/src/arduino/TempTamer/TempTamer.ino
+++ b/src/arduino/TempTamer/TempTamer.ino
@@ -11,15 +11,18 @@
 
 #include <OneWire.h>
 #include <DallasTemperature.h>
-
+#include <Bonezegei_Printf.h>
 #include "config.h"
 #include "utils.h"
 #include "fanController.h"
 #include "temperatureSensor.h"
 
+//param Stream
+Bonezegei_Printf debug(&Serial);
+
 #define LOOP_INTERVAL_MS 5
 
-boolean ledEnabled = false;
+bool ledEnabled = false;
 
 const String INIT_MESSAGE = "TempTamer Fan Controller Module v1.0";
 
@@ -54,10 +57,11 @@ void setup()
 	initBuiltInLed();
 	Serial.begin(115200);
 
+
 	Serial.println();
 	Serial.println(INIT_MESSAGE);
 
-	Serial.printf("Initial Fan Speed: %i, Min Fan Speed: %i, Temp Sensor Pin: %i, Temp Sensor Min: %i, Temp Sensor Max: %i.",
+	debug.printf("Initial Fan Speed: %i, Min Fan Speed: %i, Temp Sensor Pin: %i, Temp Sensor Min: %i, Temp Sensor Max: %i.",
 		INITIAL_FAN_SPEED,
 		MIN_FAN_SPEED,
 		TEMP_SENSOR_PIN,
@@ -70,6 +74,8 @@ void setup()
 #else
 	Serial.println("Warning: Using analogWrite(...). Please use \"#define USE_LEDC\" where possible.");
 #endif
+
+
 
 	help();
 
@@ -193,7 +199,9 @@ void processData(String data)
 
 	if (command == CMD_RESET)
 	{
-		ESP.restart();
+#ifdef ESP32
+	ESP.restart();
+#endif
 	}
 	else if (command == CMD_FAN)
 	{

--- a/src/arduino/TempTamer/config.h
+++ b/src/arduino/TempTamer/config.h
@@ -12,11 +12,43 @@
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 
-//Only ESP supports LEDC. Disable if building for Arduino AVR targets.
-#define USE_LEDC
 
-// Fan ports to use.
-const int FANS[6] = { 2, 3, 4, 6, 8, 9 };
+//ESP32 to Arduino naming pin defines. 
+#ifndef CONFIG_IDF_TARGET_ESP32
+typedef enum {
+    GPIO_NUM_0 = 0,     /*!< GPIO0, input and output */
+    GPIO_NUM_1 = 1,     /*!< GPIO1, input and output */
+    GPIO_NUM_2 = 2,     /*!< GPIO2, input and output */
+    GPIO_NUM_3 = 3,     /*!< GPIO3, input and output */
+    GPIO_NUM_4 = 4,     /*!< GPIO4, input and output */
+    GPIO_NUM_5 = 5,     /*!< GPIO5, input and output */
+    GPIO_NUM_6 = 6,     /*!< GPIO6, input and output */
+    GPIO_NUM_7 = 7,     /*!< GPIO7, input and output */
+    GPIO_NUM_8 = 8,     /*!< GPIO8, input and output */
+    GPIO_NUM_9 = 9,     /*!< GPIO9, input and output */
+    GPIO_NUM_10 = 10,   /*!< GPIO10, input and output */
+    GPIO_NUM_11 = 11,   /*!< GPIO11, input and output */
+    GPIO_NUM_12 = 12,   /*!< GPIO12, input and output */
+    GPIO_NUM_13 = 13,   /*!< GPIO13, input and output */
+    GPIO_NUM_14 = 14,   /*!< GPIO14, input and output */
+    GPIO_NUM_15 = 15,   /*!< GPIO15, input and output */
+    GPIO_NUM_16 = 16,   /*!< GPIO16, input and output */
+    GPIO_NUM_17 = 17,   /*!< GPIO17, input and output */
+    GPIO_NUM_18 = 18,   /*!< GPIO18, input and output */
+    GPIO_NUM_19 = 19,   /*!< GPIO19, input and output */
+    GPIO_NUM_20 = 20,   /*!< GPIO20, input and output */
+    GPIO_NUM_21 = 21,   /*!< GPIO21, input and output */
+    GPIO_NUM_22 = 22,   /*!< GPIO22, input and output */
+    GPIO_NUM_MAX,
+/** @endcond */
+} gpio_num_t;
+#endif
+
+//Only ESP supports LEDC. Disable if building for Arduino AVR targets.
+//#define USE_LEDC
+
+// Fan ports and number of fans to use.
+const int FANS[6] = { GPIO_NUM_19, GPIO_NUM_18, GPIO_NUM_5, GPIO_NUM_17, GPIO_NUM_16, GPIO_NUM_4 };
 
 // Initial fan speed.
 const int INITIAL_FAN_SPEED = 50;

--- a/src/arduino/TempTamer/config.h
+++ b/src/arduino/TempTamer/config.h
@@ -12,40 +12,8 @@
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 
-
-//ESP32 to Arduino naming pin defines. 
-#ifndef CONFIG_IDF_TARGET_ESP32
-typedef enum {
-    GPIO_NUM_0 = 0,     /*!< GPIO0, input and output */
-    GPIO_NUM_1 = 1,     /*!< GPIO1, input and output */
-    GPIO_NUM_2 = 2,     /*!< GPIO2, input and output */
-    GPIO_NUM_3 = 3,     /*!< GPIO3, input and output */
-    GPIO_NUM_4 = 4,     /*!< GPIO4, input and output */
-    GPIO_NUM_5 = 5,     /*!< GPIO5, input and output */
-    GPIO_NUM_6 = 6,     /*!< GPIO6, input and output */
-    GPIO_NUM_7 = 7,     /*!< GPIO7, input and output */
-    GPIO_NUM_8 = 8,     /*!< GPIO8, input and output */
-    GPIO_NUM_9 = 9,     /*!< GPIO9, input and output */
-    GPIO_NUM_10 = 10,   /*!< GPIO10, input and output */
-    GPIO_NUM_11 = 11,   /*!< GPIO11, input and output */
-    GPIO_NUM_12 = 12,   /*!< GPIO12, input and output */
-    GPIO_NUM_13 = 13,   /*!< GPIO13, input and output */
-    GPIO_NUM_14 = 14,   /*!< GPIO14, input and output */
-    GPIO_NUM_15 = 15,   /*!< GPIO15, input and output */
-    GPIO_NUM_16 = 16,   /*!< GPIO16, input and output */
-    GPIO_NUM_17 = 17,   /*!< GPIO17, input and output */
-    GPIO_NUM_18 = 18,   /*!< GPIO18, input and output */
-    GPIO_NUM_19 = 19,   /*!< GPIO19, input and output */
-    GPIO_NUM_20 = 20,   /*!< GPIO20, input and output */
-    GPIO_NUM_21 = 21,   /*!< GPIO21, input and output */
-    GPIO_NUM_22 = 22,   /*!< GPIO22, input and output */
-    GPIO_NUM_MAX,
-/** @endcond */
-} gpio_num_t;
-#endif
-
-//Only ESP supports LEDC. Disable if building for Arduino AVR targets.
-//#define USE_LEDC
+//ESP detection for keeping the pin naming scheme cross-platform and usage of LEDC that Arduino AVR does not support.
+#include "platform.h"
 
 // Fan ports and number of fans to use.
 const int FANS[6] = { GPIO_NUM_19, GPIO_NUM_18, GPIO_NUM_5, GPIO_NUM_17, GPIO_NUM_16, GPIO_NUM_4 };

--- a/src/arduino/TempTamer/config.h
+++ b/src/arduino/TempTamer/config.h
@@ -15,9 +15,6 @@
 //Only ESP supports LEDC. Disable if building for Arduino AVR targets.
 #define USE_LEDC
 
-//Only ESP supports software reset. (Arduino supports only jumping to addr 0)
-//#define ESP32
-
 // Fan ports to use.
 const int FANS[6] = { 2, 3, 4, 6, 8, 9 };
 

--- a/src/arduino/TempTamer/config.h
+++ b/src/arduino/TempTamer/config.h
@@ -12,10 +12,14 @@
 #ifndef __CONFIG_H__
 #define __CONFIG_H__
 
+//Only ESP supports LEDC. Disable if building for Arduino AVR targets.
 #define USE_LEDC
 
+//Only ESP supports software reset. (Arduino supports only jumping to addr 0)
+//#define ESP32
+
 // Fan ports to use.
-const int FANS[6] = { GPIO_NUM_19, GPIO_NUM_18, GPIO_NUM_5, GPIO_NUM_17, GPIO_NUM_16, GPIO_NUM_4 };
+const int FANS[6] = { 2, 3, 4, 6, 8, 9 };
 
 // Initial fan speed.
 const int INITIAL_FAN_SPEED = 50;

--- a/src/arduino/TempTamer/fanController.h
+++ b/src/arduino/TempTamer/fanController.h
@@ -47,7 +47,7 @@ void initFans(int percent)
 	}
 }
 
-boolean handleFanCommand(String data)
+bool handleFanCommand(String data)
 {
 	String fanIndex = data.substring(data.indexOf(SPLIT_MARKER) + 1, data.lastIndexOf(SPLIT_MARKER));
 	if (!isValidInteger(fanIndex))
@@ -89,7 +89,7 @@ boolean handleFanCommand(String data)
 	return true;
 }
 
-boolean handleMultiFanCommand(String data)
+bool handleMultiFanCommand(String data)
 {
 	int startIndex = data.indexOf(SPLIT_MARKER) + 1;
   if (startIndex == 0)

--- a/src/arduino/TempTamer/platform.h
+++ b/src/arduino/TempTamer/platform.h
@@ -1,0 +1,155 @@
+//Platform Detection
+
+#ifndef __PLATFORM_H__
+#define __PLATFORM_H__
+
+
+//Only ESP supports LEDC. Automatic disable if building for Arduino AVR targets.
+#ifdef CONFIG_IDF_TARGET_ESP32
+    #define USE_LEDC
+#elif CONFIG_IDF_TARGET_ESP32S2
+    #define USE_LEDC
+#elif CONFIG_IDF_TARGET_ESP32S3
+    #define USE_LEDC
+#elif CONFIG_IDF_TARGET_ESP32C3
+   #define USE_LEDC
+#elif CONFIG_IDF_TARGET_ESP32H2
+    #define USE_LEDC
+#endif
+
+//ESP32 to Arduino naming pin defines. 
+#ifndef CONFIG_IDF_TARGET_ESP32
+typedef enum {
+    GPIO_NUM_1 = 1,     /*!< GPIO1, input and output */
+    GPIO_NUM_2 = 2,     /*!< GPIO2, input and output */
+    GPIO_NUM_3 = 3,     /*!< GPIO3, input and output */
+    GPIO_NUM_4 = 4,     /*!< GPIO4, input and output */
+    GPIO_NUM_5 = 5,     /*!< GPIO5, input and output */
+    GPIO_NUM_6 = 6,     /*!< GPIO6, input and output */
+    GPIO_NUM_7 = 7,     /*!< GPIO7, input and output */
+    GPIO_NUM_8 = 8,     /*!< GPIO8, input and output */
+    GPIO_NUM_9 = 9,     /*!< GPIO9, input and output */
+    GPIO_NUM_10 = 10,   /*!< GPIO10, input and output */
+    GPIO_NUM_11 = 11,   /*!< GPIO11, input and output */
+    GPIO_NUM_12 = 12,   /*!< GPIO12, input and output */
+    GPIO_NUM_13 = 13,   /*!< GPIO13, input and output */
+    GPIO_NUM_14 = 14,   /*!< GPIO14, input and output */
+    GPIO_NUM_15 = 15,   /*!< GPIO15, input and output */
+    GPIO_NUM_16 = 16,   /*!< GPIO16, input and output */
+    GPIO_NUM_17 = 17,   /*!< GPIO17, input and output */
+    GPIO_NUM_18 = 18,   /*!< GPIO18, input and output */
+    GPIO_NUM_19 = 19,   /*!< GPIO19, input and output */
+    GPIO_NUM_20 = 20,   /*!< GPIO20, input and output */
+    GPIO_NUM_21 = 21,   /*!< GPIO21, input and output */
+    GPIO_NUM_22 = 22,   /*!< GPIO22, input and output */
+    GPIO_NUM_MAX,
+/** @endcond */
+} gpio_num_t;
+#elif CONFIG_IDF_TARGET_ESP32S2
+typedef enum {
+    GPIO_NUM_1 = 1,     /*!< GPIO1, input and output */
+    GPIO_NUM_2 = 2,     /*!< GPIO2, input and output */
+    GPIO_NUM_3 = 3,     /*!< GPIO3, input and output */
+    GPIO_NUM_4 = 4,     /*!< GPIO4, input and output */
+    GPIO_NUM_5 = 5,     /*!< GPIO5, input and output */
+    GPIO_NUM_6 = 6,     /*!< GPIO6, input and output */
+    GPIO_NUM_7 = 7,     /*!< GPIO7, input and output */
+    GPIO_NUM_8 = 8,     /*!< GPIO8, input and output */
+    GPIO_NUM_9 = 9,     /*!< GPIO9, input and output */
+    GPIO_NUM_10 = 10,   /*!< GPIO10, input and output */
+    GPIO_NUM_11 = 11,   /*!< GPIO11, input and output */
+    GPIO_NUM_12 = 12,   /*!< GPIO12, input and output */
+    GPIO_NUM_13 = 13,   /*!< GPIO13, input and output */
+    GPIO_NUM_14 = 14,   /*!< GPIO14, input and output */
+    GPIO_NUM_15 = 15,   /*!< GPIO15, input and output */
+    GPIO_NUM_16 = 16,   /*!< GPIO16, input and output */
+    GPIO_NUM_17 = 17,   /*!< GPIO17, input and output */
+    GPIO_NUM_18 = 18,   /*!< GPIO18, input and output */
+    GPIO_NUM_19 = 19,   /*!< GPIO19, input and output */
+    GPIO_NUM_20 = 20,   /*!< GPIO20, input and output */
+    GPIO_NUM_21 = 21,   /*!< GPIO21, input and output */
+    GPIO_NUM_MAX,
+/** @endcond */
+} gpio_num_t;
+#elif CONFIG_IDF_TARGET_ESP32S3
+typedef enum {
+    GPIO_NUM_1 = 1,     /*!< GPIO1, input and output */
+    GPIO_NUM_2 = 2,     /*!< GPIO2, input and output */
+    GPIO_NUM_3 = 3,     /*!< GPIO3, input and output */
+    GPIO_NUM_4 = 4,     /*!< GPIO4, input and output */
+    GPIO_NUM_5 = 5,     /*!< GPIO5, input and output */
+    GPIO_NUM_6 = 6,     /*!< GPIO6, input and output */
+    GPIO_NUM_7 = 7,     /*!< GPIO7, input and output */
+    GPIO_NUM_8 = 8,     /*!< GPIO8, input and output */
+    GPIO_NUM_9 = 9,     /*!< GPIO9, input and output */
+    GPIO_NUM_10 = 10,   /*!< GPIO10, input and output */
+    GPIO_NUM_11 = 11,   /*!< GPIO11, input and output */
+    GPIO_NUM_12 = 12,   /*!< GPIO12, input and output */
+    GPIO_NUM_13 = 13,   /*!< GPIO13, input and output */
+    GPIO_NUM_14 = 14,   /*!< GPIO14, input and output */
+    GPIO_NUM_15 = 15,   /*!< GPIO15, input and output */
+    GPIO_NUM_16 = 16,   /*!< GPIO16, input and output */
+    GPIO_NUM_17 = 17,   /*!< GPIO17, input and output */
+    GPIO_NUM_18 = 18,   /*!< GPIO18, input and output */
+    GPIO_NUM_19 = 19,   /*!< GPIO19, input and output */
+    GPIO_NUM_20 = 20,   /*!< GPIO20, input and output */
+    GPIO_NUM_21 = 21,   /*!< GPIO21, input and output */
+    GPIO_NUM_MAX,
+/** @endcond */
+} gpio_num_t;
+#elif CONFIG_IDF_TARGET_ESP32C3
+typedef enum {
+    GPIO_NUM_1 = 1,     /*!< GPIO1, input and output */
+    GPIO_NUM_2 = 2,     /*!< GPIO2, input and output */
+    GPIO_NUM_3 = 3,     /*!< GPIO3, input and output */
+    GPIO_NUM_4 = 4,     /*!< GPIO4, input and output */
+    GPIO_NUM_5 = 5,     /*!< GPIO5, input and output */
+    GPIO_NUM_6 = 6,     /*!< GPIO6, input and output */
+    GPIO_NUM_7 = 7,     /*!< GPIO7, input and output */
+    GPIO_NUM_8 = 8,     /*!< GPIO8, input and output */
+    GPIO_NUM_9 = 9,     /*!< GPIO9, input and output */
+    GPIO_NUM_10 = 10,   /*!< GPIO10, input and output */
+    GPIO_NUM_11 = 11,   /*!< GPIO11, input and output */
+    GPIO_NUM_12 = 12,   /*!< GPIO12, input and output */
+    GPIO_NUM_13 = 13,   /*!< GPIO13, input and output */
+    GPIO_NUM_14 = 14,   /*!< GPIO14, input and output */
+    GPIO_NUM_15 = 15,   /*!< GPIO15, input and output */
+    GPIO_NUM_16 = 16,   /*!< GPIO16, input and output */
+    GPIO_NUM_17 = 17,   /*!< GPIO17, input and output */
+    GPIO_NUM_18 = 18,   /*!< GPIO18, input and output */
+    GPIO_NUM_19 = 19,   /*!< GPIO19, input and output */
+    GPIO_NUM_20 = 20,   /*!< GPIO20, input and output */
+    GPIO_NUM_21 = 21,   /*!< GPIO21, input and output */
+    GPIO_NUM_MAX,
+/** @endcond */
+} gpio_num_t;
+#elif CONFIG_IDF_TARGET_ESP32H2
+typedef enum {
+    GPIO_NUM_1 = 1,     /*!< GPIO1, input and output */
+    GPIO_NUM_2 = 2,     /*!< GPIO2, input and output */
+    GPIO_NUM_3 = 3,     /*!< GPIO3, input and output */
+    GPIO_NUM_4 = 4,     /*!< GPIO4, input and output */
+    GPIO_NUM_5 = 5,     /*!< GPIO5, input and output */
+    GPIO_NUM_6 = 6,     /*!< GPIO6, input and output */
+    GPIO_NUM_7 = 7,     /*!< GPIO7, input and output */
+    GPIO_NUM_8 = 8,     /*!< GPIO8, input and output */
+    GPIO_NUM_9 = 9,     /*!< GPIO9, input and output */
+    GPIO_NUM_10 = 10,   /*!< GPIO10, input and output */
+    GPIO_NUM_11 = 11,   /*!< GPIO11, input and output */
+    GPIO_NUM_12 = 12,   /*!< GPIO12, input and output */
+    GPIO_NUM_13 = 13,   /*!< GPIO13, input and output */
+    GPIO_NUM_14 = 14,   /*!< GPIO14, input and output */
+    GPIO_NUM_15 = 15,   /*!< GPIO15, input and output */
+    GPIO_NUM_16 = 16,   /*!< GPIO16, input and output */
+    GPIO_NUM_17 = 17,   /*!< GPIO17, input and output */
+    GPIO_NUM_18 = 18,   /*!< GPIO18, input and output */
+    GPIO_NUM_19 = 19,   /*!< GPIO19, input and output */
+    GPIO_NUM_20 = 20,   /*!< GPIO20, input and output */
+    GPIO_NUM_21 = 21,   /*!< GPIO21, input and output */
+    GPIO_NUM_22 = 22,   /*!< GPIO22, input and output */
+    GPIO_NUM_MAX,
+/** @endcond */
+} gpio_num_t;
+#endif
+
+#endif

--- a/src/arduino/TempTamer/utils.h
+++ b/src/arduino/TempTamer/utils.h
@@ -9,6 +9,7 @@
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // MIT License for more details.
 
+#include <Arduino.h>
 #ifndef __UTILS_H__
 #define __UTILS_H__
 
@@ -69,7 +70,7 @@ String readSerialData(int maxLength = 100)
 	return "";
 }
 
-boolean isValidInteger(String str)
+bool isValidInteger(String str)
 {
 	if (str == NULL || str.length() == 0)
 	{

--- a/src/arduino/TempTamer/utils.h
+++ b/src/arduino/TempTamer/utils.h
@@ -18,6 +18,8 @@
 #define END_MARKER '}'
 #define SPLIT_MARKER ","
 
+
+
 String readSerialData(int maxLength = 100)
 {
 	// Wait in total 100ms (100 iterations with 1ms delay) for data in case of slow transfers.
@@ -30,7 +32,7 @@ String readSerialData(int maxLength = 100)
 	unsigned long startTime = millis();
 	unsigned long totalDelayIterator = 0;
 
-	boolean error = false;
+	bool error = false;
 	while (Serial.available())
 	{
 		char c = Serial.read();


### PR DESCRIPTION
Work in Progress

Created platform.h for detecting platforms, now supports ESP32,ESP8266,ESP-12,ArduinoAVR.
Added printf lib for Arduino formatted serial output support.
ESP32 pin naming scheme  Example: "GPIO_NUM_3" on all platforms.
Moved #define LEDC to platform.h for Arduino AVR does not support it.
